### PR TITLE
Recognize HTTP PATCH method

### DIFF
--- a/lib/APISchema/DSL.pm
+++ b/lib/APISchema/DSL.pm
@@ -18,7 +18,7 @@ my %schema_meta = (
 );
 
 our %METHODS = (
-    ( map { $_ => $_ } qw(HEAD GET POST PUT DELETE) ),
+    ( map { $_ => $_ } qw(HEAD GET POST PUT DELETE PATCH) ),
     FETCH => [qw(GET HEAD)],
 );
 our @DIRECTIVES = (qw(include filter resource title description), keys %METHODS);

--- a/t/APISchema-DSL.t
+++ b/t/APISchema-DSL.t
@@ -76,6 +76,32 @@ sub process : Tests {
         };
     };
 
+    subtest 'Support PATCH' => sub {
+        lives_ok {
+            my $schema = APISchema::DSL::process {
+                PATCH '/my' => {
+                    title       => 'Update My BMI',
+                    destination => {
+                        controller => 'BMI',
+                        action     => 'update',
+                    },
+                };
+            };
+            isa_ok $schema, 'APISchema::Schema';
+
+            my $routes = $schema->get_routes;
+            is scalar @$routes, 1;
+
+            is $routes->[0]->route, '/my';
+            is $routes->[0]->title, 'Update My BMI';
+            is $routes->[0]->method, 'PATCH';
+            is_deeply $routes->[0]->destination, {
+                controller => 'BMI',
+                action     => 'update',
+            };
+        };
+    };
+
     subtest 'Validation should be returned' => sub {
         lives_ok {
             my $schema = APISchema::DSL::process {


### PR DESCRIPTION
The current status of HTTP PATCH method is `PROPOSED STANDARD`, but is is known and implemented by some libraries such as Rails or Express.

It is useful to represent partial resource modification that is very common idiom among web application developers.

cf. [PATCH Method for HTTP (RFC5789)](http://tools.ietf.org/html/rfc5789)
