### PR TITLE
RequestValidator can resolve a status code from last validation result

### DIFF
--- a/lib/Plack/Middleware/APISchema/RequestValidator.pm
+++ b/lib/Plack/Middleware/APISchema/RequestValidator.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 
 use parent qw(Plack::Middleware);
-use Plack::Util::Accessor qw(schema validator status_code);
+use Plack::Util::Accessor qw(schema validator status_code_resolver);
 use Plack::Request;
 use APISchema::Generator::Router::Simple;
 use APISchema::Validator;
@@ -32,7 +32,7 @@ sub call {
     }, $self->schema);
 
     my $errors = $result->errors;
-    my $status_code = $self->status_code // 400;
+    my $status_code = ($self->status_code_resolver // sub { 400 })->($result);
     return [
         $status_code,
         [ 'Content-Type' => 'application/json' ],


### PR DESCRIPTION
Plack::MW::APISchema::RequestValidator already has `#status_code`, but it is statically resolved.

So it always returns same status code if request's content-type is wrong or request's body is malformed.

However useful and semantic web API is required to return the response with detailed status code.

`#status_code_resolver` takes a CodeRef that takes `APISchema::Validation::Result` and returns HTTP status code.
