### PR TITLE
Prettify the output of examples

### DIFF
--- a/lib/APISchema/Generator/Markdown.pm
+++ b/lib/APISchema/Generator/Markdown.pm
@@ -214,7 +214,7 @@ HTTP/1.1 <?= http_status($code) ?><?= $example->header ?><?= $example->body ?>
 ? my ($r, $resource, $properties) = @_;
 ### <a name="<?= anchor(resource => $resource) ?>"></a> `<?= $resource->title ?>` : <?= type($resource->definition) ?>
 ```javascript
-<?= json $r->example($resource->definition) ?>
+<?= pretty_json $r->example($resource->definition) ?>
 ```
 
 ?= $resource->definition->{description} || ''

--- a/lib/APISchema/Generator/Markdown/Formatter.pm
+++ b/lib/APISchema/Generator/Markdown/Formatter.pm
@@ -3,7 +3,7 @@ use 5.014;
 
 # core
 use Exporter qw(import);
-our @EXPORT = qw(type json code restriction desc anchor method methods content_type http_status http_status_code);
+our @EXPORT = qw(type json pretty_json code restriction desc anchor method methods content_type http_status http_status_code);
 
 # cpan
 use HTTP::Status qw(status_message);
@@ -47,6 +47,18 @@ sub json ($) {
     } else {
         $x = $JSON->encode([$x]);
         $x =~ s/^\[(.*)\]$/$1/;
+    }
+    return $x;
+}
+
+my $PRETTY_JSON = JSON::XS->new->canonical(1)->indent(1)->pretty(1);
+sub pretty_json ($) {
+    my $x = shift;
+    if (ref $x) {
+        $x = $PRETTY_JSON->encode($x);
+    } else {
+        $x = $PRETTY_JSON->encode([$x]);
+        $x =~ s/^\[\s*(.*)\s*\]\n$/$1/;
     }
     return $x;
 }

--- a/t/APISchema-Generator-Markdown.t
+++ b/t/APISchema-Generator-Markdown.t
@@ -3,6 +3,8 @@ use t::test;
 use t::test::fixtures;
 use utf8;
 
+use APISchema::DSL;
+
 sub _require : Test(startup => 1) {
     my ($self) = @_;
 
@@ -59,6 +61,20 @@ EOS
         like $markdown, qr{\nHTTP/1.1 200 OK\nSucceeded!\n};
         like $markdown, qr{#### Response `400 Bad Request`};
     };
+
+    subtest 'example with no containers' => sub {
+        my $schema = APISchema::DSL::process {
+          resource gender => {
+            enum => ['male', 'female', 'other'],
+            example => 'other',
+          };
+        };
+
+        my $generator = APISchema::Generator::Markdown->new;
+        my $markdown = $generator->format_schema($schema);
+
+        like $markdown, qr/^"other"$/m;
+    };
 }
 
 sub generate_utf8 : Tests {
@@ -68,7 +84,7 @@ sub generate_utf8 : Tests {
         my $generator = APISchema::Generator::Markdown->new;
         my $markdown = $generator->format_schema($schema);
 
-        like $markdown, qr!\Q{"first_name":"小飼","last_name":"弾"}\E!;
+        like $markdown, qr!{\n   "first_name" : "小飼",\n   "last_name" : "弾"\n}!;
         like $markdown, qr!\Q|`.last_name` |`string` | |`"弾"` | |名 |\E!;
     };
 }


### PR DESCRIPTION
Before:

``` json
{"height":1.6,"weight":50}
```

After:

``` json
{
  "height" : 1.6,
  "weight" : 50
}
```

Prettified output is readable, especially complexed structure.
