### PR TITLE
Determine the status code from the detail of failure

### DIFF
--- a/lib/Plack/Middleware/APISchema/RequestValidator.pm
+++ b/lib/Plack/Middleware/APISchema/RequestValidator.pm
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 
 use parent qw(Plack::Middleware);
+use HTTP::Status qw(:constants);
 use Plack::Util::Accessor qw(schema validator status_code);
 use Plack::Request;
 use APISchema::Generator::Router::Simple;
@@ -32,7 +33,7 @@ sub call {
     }, $self->schema);
 
     my $errors = $result->errors;
-    my $status_code = $self->status_code // 400;
+    my $status_code = $self->_resolve_status_code($result);
     return [
         $status_code,
         [ 'Content-Type' => 'application/json' ],
@@ -49,6 +50,12 @@ sub router {
         my $generator = APISchema::Generator::Router::Simple->new;
         $generator->generate_router($self->schema);
     };
+}
+
+sub _resolve_status_code {
+    my ($self, $validation_result) = @_;
+    my $error_message = $validation_result->errors->{body}->{message} // '';
+    return $error_message =~ m/Wrong content-type/ ? HTTP_UNSUPPORTED_MEDIA_TYPE : HTTP_UNPROCESSABLE_ENTITY;
 }
 
 

--- a/lib/Plack/Middleware/APISchema/RequestValidator.pm
+++ b/lib/Plack/Middleware/APISchema/RequestValidator.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use parent qw(Plack::Middleware);
 use HTTP::Status qw(:constants);
-use Plack::Util::Accessor qw(schema validator status_code);
+use Plack::Util::Accessor qw(schema validator);
 use Plack::Request;
 use APISchema::Generator::Router::Simple;
 use APISchema::Validator;

--- a/t/Plack-Middleware-APISchema-RequestValidator.t
+++ b/t/Plack-Middleware-APISchema-RequestValidator.t
@@ -117,33 +117,6 @@ sub request_validator : Tests {
         }
     };
 
-    subtest 'when invalid request (with explicit error status code)' => sub {
-        my $middleware_with_status_code = Plack::Middleware::APISchema::RequestValidator->new(schema => $schema, status_code => 422);
-        $middleware_with_status_code->wrap(sub {
-            [200, [ 'Content-Type' => 'text/plain' ], [ 'dummy' ]  ]
-        });
-        test_psgi $middleware_with_status_code => sub {
-            my $server = shift;
-            my $res = $server->(
-                POST '/bmi',
-                Content_Type => 'application/json',
-                Content => encode_json({}),
-            );
-            is $res->code, 422;
-            cmp_deeply $res->content, json({
-                body => {
-                    attribute => 'Valiemon::Attributes::Required',
-                    position => '/$ref/required',
-                    message => "Contents do not match resource 'figure'",
-                    encoding => 'json',
-                    actual => {},
-                    expected => $schema->get_resource_by_name('figure')->definition,
-                },
-            });
-            done_testing;
-        }
-    };
-
     subtest 'other endpoints are not affected' => sub {
         test_psgi $middleware => sub {
             my $server = shift;

--- a/t/Plack-Middleware-APISchema-RequestValidator.t
+++ b/t/Plack-Middleware-APISchema-RequestValidator.t
@@ -3,6 +3,7 @@ use t::test;
 use t::test::fixtures;
 use Plack::Test;
 use HTTP::Request::Common;
+use HTTP::Status qw(:constants);
 use JSON::XS qw(encode_json);
 
 sub _require : Test(startup => 1) {
@@ -101,7 +102,7 @@ sub request_validator : Tests {
                 Content_Type => 'application/json',
                 Content => encode_json({}),
             );
-            is $res->code, 400;
+            is $res->code, HTTP_UNPROCESSABLE_ENTITY;
             cmp_deeply $res->content, json({
                 body => {
                     attribute => 'Valiemon::Attributes::Required',
@@ -159,7 +160,7 @@ sub request_validator : Tests {
                 Content_Type => 'application/json',
                 Content => 'aaa',
             );
-            is $res->code, 400;
+            is $res->code, HTTP_UNPROCESSABLE_ENTITY;
             cmp_deeply $res->content, json({
                 body => {
                     message => "Failed to parse json",
@@ -179,7 +180,7 @@ sub request_validator : Tests {
                 Content_Type => $content_type,
                 Content => encode_json({weight => 50, height => 1.6}),
             );
-            is $res->code, 400;
+            is $res->code, HTTP_UNPROCESSABLE_ENTITY;
             cmp_deeply $res->content, json({
                 body => {
                     attribute => 'Valiemon::Attributes::Required',
@@ -219,7 +220,7 @@ sub request_validator : Tests {
                 Content_Type => $content_type,
                 Content => encode_json({weight => 50, height => 1.6}),
             );
-            is $res->code, 400;
+            is $res->code, HTTP_UNSUPPORTED_MEDIA_TYPE;
             cmp_deeply $res->content, json({
                 body => { message => "Wrong content-type: $content_type" },
             });
@@ -244,7 +245,7 @@ sub request_validator : Tests {
             my $res = $server->(
                 POST '/bmi_by_parameter?weight=50',
             );
-            is $res->code, 400;
+            is $res->code, HTTP_UNPROCESSABLE_ENTITY;
             cmp_deeply $res->content, json({
                 parameter => {
                     attribute => 'Valiemon::Attributes::Required',
@@ -281,7 +282,7 @@ sub request_validator : Tests {
                 POST '/bmi_by_header',
                 X_Weight => 50,
             );
-            is $res->code, 400;
+            is $res->code, HTTP_UNPROCESSABLE_ENTITY;
             cmp_deeply $res->content, json({
                 header => {
                     attribute => 'Valiemon::Attributes::Required',
@@ -328,7 +329,7 @@ sub request_validator_with_utf8 : Tests {
                     last_name => [],
                 }),
             );
-            is $res->code, 400;
+            is $res->code, HTTP_UNPROCESSABLE_ENTITY;
             cmp_deeply $res->content, json({
                 body  => {
                     actual    => [],


### PR DESCRIPTION
If `Content-Type` is wrong, RequestValidator returns 415 (Unsupported Media Type), otherwise 422 (Unprocessable Entity).
